### PR TITLE
Move versioning to separate pipeline job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -45,8 +43,15 @@ jobs:
           healthcheck: "https://thawing-ocean-77154.herokuapp.com/health"
           checkstring: "ok"
           rollbackonhealthcheckfailed: true
+  tag_version:
+    needs: simple_deployment_pipeline
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Bump version and push tag
-        if: ${{ github.event_name == 'push' }}
         uses: anothrNick/github-tag-action@1.35.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creating a tag after the Heroku deployment phase at the end of the job resulted in a tag creation error. Trying if the suggested separate job will solve the issue.